### PR TITLE
configure: Additional C99 compatibility fixes

### DIFF
--- a/configure
+++ b/configure
@@ -172,7 +172,7 @@ rm -f fake_makefile*
 echo -n "cc... "
 cat <<EOF > fake_cc.c
 #include <stdio.h>
-main() { printf("woot\n"); }
+int main(void) { printf("woot\n"); }
 EOF
 if ! ${CC} fake_cc.c -o /dev/null 1>/dev/null 2>/dev/null; then
 	not_found "No C compiler found (try to install gcc or clang)"
@@ -185,7 +185,7 @@ rm -f fake_cc*
 echo -n "strlcpy... "
 cat <<EOF > fake_strlcpy.c
 #include <string.h>
-main() { char buf[32]; strlcpy(buf, "woot", sizeof(buf)); }
+int main(void) { char buf[32]; strlcpy(buf, "woot", sizeof(buf)); }
 EOF
 if ! ${CC} fake_strlcpy.c -o /dev/null 1>/dev/null 2>/dev/null; then
 	echo "not found (we'll use ours)"
@@ -201,7 +201,7 @@ rm -f fake_strlcpy*
 echo -n "wcslcpy... "
 cat <<EOF > fake_wcslcpy.c
 #include <wchar.h>
-main() { wchar_t buf[32]; wcslcpy(buf, L"woot", sizeof(buf)); }
+int main(void) { wchar_t buf[32]; wcslcpy(buf, L"woot", sizeof(buf)); }
 EOF
 if ! ${CC} fake_wcslcpy.c -o /dev/null 1>/dev/null 2>/dev/null; then
 	echo "not found (we'll use ours)"
@@ -215,7 +215,7 @@ rm -f fake_wcslcpy*
 # Check if we have wcstonum
 echo -n "wcstonum... "
 cat <<EOF > fake_wcstonum.c
-main() { int i; const char *errstr; i = wcstonum("42", 1, 64, &errstr); }
+int main(void) { int i; const char *errstr; i = wcstonum("42", 1, 64, &errstr); }
 EOF
 if ! ${CC} fake_wcstonum.c -o /dev/null 1>/dev/null 2>/dev/null; then
 	echo "not found (we'll use ours)"


### PR DESCRIPTION
This corrects more instances of missing headers and implicit ints, as in commit cc8a7bfc6252a1e69d9ae9c2a76918155e9cd7f0.  It will help to avoid build failures with future compilers.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
